### PR TITLE
chore: Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,16 +19,16 @@
     "ng-schematics": "./bin/ng-schematics.js"
   },
   "dependencies": {
-    "@angular-devkit/core": "^9.1.1",
-    "@angular-devkit/schematics": "^9.1.1",
-    "@angular-devkit/schematics-cli": "^0.901.1",
-    "@types/jasmine": "^3.3.9",
-    "@types/node": "^8.0.31",
-    "jasmine": "^3.3.1",
-    "typescript": "~3.5.3"
+    "@angular-devkit/core": "^11.0.5",
+    "@angular-devkit/schematics": "^11.0.5",
+    "@schematics/angular": "^11.0.5",
+    "typescript": "~4.0.2"
   },
   "devDependencies": {
-    "@schematics/angular": "^9.1.1",
+    "@angular-devkit/schematics-cli": "^0.1100.5",
+    "@types/jasmine": "~3.5.0",
+    "@types/node": "^12.11.1",
+    "jasmine": "^3.5.0",
     "prettier": "2.2.1"
   }
 }

--- a/src/ngrx-store/index.spec.ts
+++ b/src/ngrx-store/index.spec.ts
@@ -53,10 +53,10 @@ describe('ngrx-store', () => {
   let runner: SchematicTestRunner;
   let tree: UnitTestTree;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     const args = { name: fileName, env: 'test' };
     runner = new SchematicTestRunner('schematics', collectionPath);
-    tree = runner.runSchematic('ngrx-store', args, Tree.empty());
+    tree = await runner.runSchematicAsync('ngrx-store', args, Tree.empty()).toPromise();
   });
 
   it('生成されるファイル名の確認', () => {

--- a/src/ngrx-store/index.ts
+++ b/src/ngrx-store/index.ts
@@ -1,12 +1,12 @@
-import { experimental, normalize, strings } from '@angular-devkit/core';
+import { normalize, strings } from '@angular-devkit/core';
 import { apply, applyTemplates, chain, mergeWith, move, Rule, SchematicsException, Tree, url } from '@angular-devkit/schematics';
+import { ProjectType, WorkspaceSchema } from '@schematics/angular/utility/workspace-models';
 import { Schema as NgRxStoreSchema } from './schema';
 
 export function ngRxStore(options: NgRxStoreSchema): Rule {
   return (tree: Tree) => {
     // parse workspace string into JSON object
-    const workspace: experimental.workspace.WorkspaceSchema =
-      options.env === 'test' ? getWorkspaceForTestEnvironment() : getWorkspace(tree);
+    const workspace: WorkspaceSchema = options.env === 'test' ? getWorkspaceForTestEnvironment() : getWorkspace(tree);
 
     if (!options.project) {
       options.project = workspace.defaultProject;
@@ -28,7 +28,7 @@ export function ngRxStore(options: NgRxStoreSchema): Rule {
   };
 }
 
-function getWorkspace(tree: Tree): experimental.workspace.WorkspaceSchema {
+function getWorkspace(tree: Tree): WorkspaceSchema {
   const workspaceConfig = tree.read('/angular.json');
   if (!workspaceConfig) {
     throw new SchematicsException('Could not find Angular workspace configuration');
@@ -41,10 +41,10 @@ function getWorkspace(tree: Tree): experimental.workspace.WorkspaceSchema {
   return JSON.parse(workspaceContent);
 }
 
-function getWorkspaceForTestEnvironment(): experimental.workspace.WorkspaceSchema {
+function getWorkspaceForTestEnvironment(): WorkspaceSchema {
   return {
     projects: {
-      'ng-schematics': { projectType: 'application', sourceRoot: 'src', root: '', prefix: 'app' },
+      'ng-schematics': { projectType: ProjectType.Application, sourceRoot: 'src', root: '', prefix: 'app' },
     },
     defaultProject: 'ng-schematics',
     version: 1,

--- a/src/query/index.ts
+++ b/src/query/index.ts
@@ -1,12 +1,12 @@
-import { experimental, normalize, strings } from '@angular-devkit/core';
+import { normalize, strings } from '@angular-devkit/core';
 import { apply, applyTemplates, chain, mergeWith, move, Rule, SchematicsException, Tree, url } from '@angular-devkit/schematics';
+import { ProjectType, WorkspaceSchema } from '@schematics/angular/utility/workspace-models';
 import { Schema as QuerySchema } from './schema';
 
 export function generate(options: QuerySchema): Rule {
   return (tree: Tree) => {
     // parse workspace string into JSON object
-    const workspace: experimental.workspace.WorkspaceSchema =
-      options.env === 'test' ? getWorkspaceForTestEnvironment() : getWorkspace(tree);
+    const workspace: WorkspaceSchema = options.env === 'test' ? getWorkspaceForTestEnvironment() : getWorkspace(tree);
 
     if (!options.project) {
       options.project = workspace.defaultProject;
@@ -28,7 +28,7 @@ export function generate(options: QuerySchema): Rule {
   };
 }
 
-function getWorkspace(tree: Tree): experimental.workspace.WorkspaceSchema {
+function getWorkspace(tree: Tree): WorkspaceSchema {
   const workspaceConfig = tree.read('/angular.json');
   if (!workspaceConfig) {
     throw new SchematicsException('Could not find Angular workspace configuration');
@@ -41,10 +41,10 @@ function getWorkspace(tree: Tree): experimental.workspace.WorkspaceSchema {
   return JSON.parse(workspaceContent);
 }
 
-function getWorkspaceForTestEnvironment(): experimental.workspace.WorkspaceSchema {
+function getWorkspaceForTestEnvironment(): WorkspaceSchema {
   return {
     projects: {
-      'ng-schematics': { projectType: 'application', sourceRoot: 'src', root: '', prefix: 'app' },
+      'ng-schematics': { projectType: ProjectType.Application, sourceRoot: 'src', root: '', prefix: 'app' },
     },
     defaultProject: 'ng-schematics',
     version: 1,

--- a/src/repository/index.ts
+++ b/src/repository/index.ts
@@ -1,12 +1,12 @@
-import { experimental, normalize, strings } from '@angular-devkit/core';
+import { normalize, strings } from '@angular-devkit/core';
 import { apply, applyTemplates, chain, mergeWith, move, Rule, SchematicsException, Tree, url } from '@angular-devkit/schematics';
+import { ProjectType, WorkspaceSchema } from '@schematics/angular/utility/workspace-models';
 import { Schema as RepositorySchema } from './schema';
 
 export function generate(options: RepositorySchema): Rule {
   return (tree: Tree) => {
     // parse workspace string into JSON object
-    const workspace: experimental.workspace.WorkspaceSchema =
-      options.env === 'test' ? getWorkspaceForTestEnvironment() : getWorkspace(tree);
+    const workspace: WorkspaceSchema = options.env === 'test' ? getWorkspaceForTestEnvironment() : getWorkspace(tree);
 
     if (!options.project) {
       options.project = workspace.defaultProject;
@@ -28,7 +28,7 @@ export function generate(options: RepositorySchema): Rule {
   };
 }
 
-function getWorkspace(tree: Tree): experimental.workspace.WorkspaceSchema {
+function getWorkspace(tree: Tree): WorkspaceSchema {
   const workspaceConfig = tree.read('/angular.json');
   if (!workspaceConfig) {
     throw new SchematicsException('Could not find Angular workspace configuration');
@@ -41,10 +41,10 @@ function getWorkspace(tree: Tree): experimental.workspace.WorkspaceSchema {
   return JSON.parse(workspaceContent);
 }
 
-function getWorkspaceForTestEnvironment(): experimental.workspace.WorkspaceSchema {
+function getWorkspaceForTestEnvironment(): WorkspaceSchema {
   return {
     projects: {
-      'ng-schematics': { projectType: 'application', sourceRoot: 'src', root: '', prefix: 'app' },
+      'ng-schematics': { projectType: ProjectType.Application, sourceRoot: 'src', root: '', prefix: 'app' },
     },
     defaultProject: 'ng-schematics',
     version: 1,

--- a/src/usecase/index.ts
+++ b/src/usecase/index.ts
@@ -1,12 +1,15 @@
-import { experimental, normalize, strings } from '@angular-devkit/core';
+import { normalize, strings } from '@angular-devkit/core';
 import { apply, applyTemplates, chain, mergeWith, move, Rule, SchematicsException, Tree, url } from '@angular-devkit/schematics';
+import { ProjectType, WorkspaceSchema } from '@schematics/angular/utility/workspace-models';
 import { Schema as UsecaseSchema } from './schema';
 
 export function generate(options: UsecaseSchema): Rule {
   return (tree: Tree) => {
     // parse workspace string into JSON object
-    const workspace: experimental.workspace.WorkspaceSchema =
-      options.env === 'test' ? getWorkspaceForTestEnvironment() : getWorkspace(tree);
+    const workspace: WorkspaceSchema = options.env === 'test' ? getWorkspaceForTestEnvironment() : getWorkspace(tree);
+
+    // const workspace: experimental.workspace.WorkspaceSchema =
+    //   options.env === 'test' ? getWorkspaceForTestEnvironment() : getWorkspace(tree);
 
     if (!options.project) {
       options.project = workspace.defaultProject;
@@ -28,7 +31,7 @@ export function generate(options: UsecaseSchema): Rule {
   };
 }
 
-function getWorkspace(tree: Tree): experimental.workspace.WorkspaceSchema {
+function getWorkspace(tree: Tree): WorkspaceSchema {
   const workspaceConfig = tree.read('/angular.json');
   if (!workspaceConfig) {
     throw new SchematicsException('Could not find Angular workspace configuration');
@@ -41,10 +44,11 @@ function getWorkspace(tree: Tree): experimental.workspace.WorkspaceSchema {
   return JSON.parse(workspaceContent);
 }
 
-function getWorkspaceForTestEnvironment(): experimental.workspace.WorkspaceSchema {
+function getWorkspaceForTestEnvironment(): WorkspaceSchema {
   return {
     projects: {
-      'ng-schematics': { projectType: 'application', sourceRoot: 'src', root: '', prefix: 'app' },
+      // 'ng-schematics': { projectType: 'application', sourceRoot: 'src', root: '', prefix: 'app' },
+      'ng-schematics': { projectType: ProjectType.Application, sourceRoot: 'src', root: '', prefix: 'app' },
     },
     defaultProject: 'ng-schematics',
     version: 1,

--- a/src/user-defined/index.ts
+++ b/src/user-defined/index.ts
@@ -1,12 +1,12 @@
-import { experimental, normalize, strings } from '@angular-devkit/core';
+import { normalize, strings } from '@angular-devkit/core';
 import { apply, applyTemplates, chain, mergeWith, move, Rule, SchematicsException, Tree, url } from '@angular-devkit/schematics';
+import { ProjectType, WorkspaceSchema } from '@schematics/angular/utility/workspace-models';
 import { Schema as NgRxStoreSchema } from './schema';
 
 export function genarate(options: NgRxStoreSchema): Rule {
   return (tree: Tree) => {
     // parse workspace string into JSON object
-    const workspace: experimental.workspace.WorkspaceSchema =
-      options.env === 'test' ? getWorkspaceForTestEnvironment() : getWorkspace(tree);
+    const workspace: WorkspaceSchema = options.env === 'test' ? getWorkspaceForTestEnvironment() : getWorkspace(tree);
 
     if (!options.project) {
       options.project = workspace.defaultProject;
@@ -31,7 +31,7 @@ export function genarate(options: NgRxStoreSchema): Rule {
   };
 }
 
-function getWorkspace(tree: Tree): experimental.workspace.WorkspaceSchema {
+function getWorkspace(tree: Tree): WorkspaceSchema {
   const workspaceConfig = tree.read('/angular.json');
   if (!workspaceConfig) {
     throw new SchematicsException('Could not find Angular workspace configuration');
@@ -44,10 +44,10 @@ function getWorkspace(tree: Tree): experimental.workspace.WorkspaceSchema {
   return JSON.parse(workspaceContent);
 }
 
-function getWorkspaceForTestEnvironment(): experimental.workspace.WorkspaceSchema {
+function getWorkspaceForTestEnvironment(): WorkspaceSchema {
   return {
     projects: {
-      'ng-schematics': { projectType: 'application', sourceRoot: 'src', root: '', prefix: 'app' },
+      'ng-schematics': { projectType: ProjectType.Application, sourceRoot: 'src', root: '', prefix: 'app' },
     },
     defaultProject: 'ng-schematics',
     version: 1,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,79 +2,85 @@
 # yarn lockfile v1
 
 
-"@angular-devkit/core@9.1.1", "@angular-devkit/core@^9.1.1":
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/core/-/core-9.1.1.tgz#6adb04c17d01abea506b8f2bd041aacdd569dc4f"
-  integrity sha512-57MNew2u1QwVb69jxZyhXgdW9kqcGyWyRy2ui/hWCkWLg7RumWtyypmdTs89FNExB4HqtXlQ2eO3JZxfs7QR3w==
+"@angular-devkit/core@11.0.5", "@angular-devkit/core@^11.0.5":
+  version "11.0.5"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/core/-/core-11.0.5.tgz#8239486d2de6c08fc55d2a64f12a7f5d518c8beb"
+  integrity sha512-hwV8fjF8JNPJkiVWw8MNzeIfDo01aD/OAOlC4L5rQnVHn+i2EiU3brSDmFqyeHPPV3h/QjuBkS3tkN7gSnVWaQ==
   dependencies:
-    ajv "6.12.0"
+    ajv "6.12.6"
     fast-json-stable-stringify "2.1.0"
     magic-string "0.25.7"
-    rxjs "6.5.4"
+    rxjs "6.6.3"
     source-map "0.7.3"
 
-"@angular-devkit/schematics-cli@^0.901.1":
-  version "0.901.1"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/schematics-cli/-/schematics-cli-0.901.1.tgz#bc760be337087386f811a717bd34038c905fca81"
-  integrity sha512-huy/ggyfJhbYUIPCrGjqUcZ26/y7U6+ow01IWeYbY884/G627o35wpDzEvSNeZY9iz0pw4abb5oM0+tA5KS0wQ==
+"@angular-devkit/schematics-cli@^0.1100.5":
+  version "0.1100.5"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/schematics-cli/-/schematics-cli-0.1100.5.tgz#5702140cf5a1ee134fb16402866360c35388c089"
+  integrity sha512-nFaYMXriKaJpZb/TdVfM/ZGAfro/5FFJwhpVYEAB4uEHQ11/7oG0gKR5pk3PBzFEzGQRve9Jv5bn3qAXlmsj8Q==
   dependencies:
-    "@angular-devkit/core" "9.1.1"
-    "@angular-devkit/schematics" "9.1.1"
-    "@schematics/schematics" "0.901.1"
-    inquirer "7.1.0"
+    "@angular-devkit/core" "11.0.5"
+    "@angular-devkit/schematics" "11.0.5"
+    "@schematics/schematics" "0.1100.5"
+    ansi-colors "4.1.1"
+    inquirer "7.3.3"
     minimist "1.2.5"
-    rxjs "6.5.4"
-    symbol-observable "1.2.0"
+    symbol-observable "2.0.3"
 
-"@angular-devkit/schematics@9.1.1", "@angular-devkit/schematics@^9.1.1":
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/schematics/-/schematics-9.1.1.tgz#8ee93a6297416271002986dbf48f08ad0911a47e"
-  integrity sha512-6wx2HcvafHvEjEa1tjDzW2hXrOiSE8ALqJUArb3+NoO1BDM42aGcqyPo0ODzKtDk12CgSsFXdNKRpQ5AmpSPtw==
+"@angular-devkit/schematics@11.0.5", "@angular-devkit/schematics@^11.0.5":
+  version "11.0.5"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/schematics/-/schematics-11.0.5.tgz#e5d89451daa644eccce93970709f7cdf44c11982"
+  integrity sha512-0NKGC8Nf/4vvDpWKB7bwxIazvNnNHnZBX6XlyBXNl+fW8tpTef3PNMJMSErTz9LFnuv61vsKbc36u/Ek2YChWg==
   dependencies:
-    "@angular-devkit/core" "9.1.1"
-    ora "4.0.3"
-    rxjs "6.5.4"
+    "@angular-devkit/core" "11.0.5"
+    ora "5.1.0"
+    rxjs "6.6.3"
 
-"@schematics/angular@^9.1.1":
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/@schematics/angular/-/angular-9.1.1.tgz#5069f8f214fa2effb68a937cfb808ec612debe96"
-  integrity sha512-V0DcDNgHQ2YR+PGZI6+pf/mUNNxt5SusShkZ1PbwIMk/HUQpzEGkLjm3v1Jw9eIZKiuDx615GNU1xDzQ/KyNRQ==
+"@schematics/angular@^11.0.5":
+  version "11.0.5"
+  resolved "https://registry.yarnpkg.com/@schematics/angular/-/angular-11.0.5.tgz#149f908fd600e881ff87c5192d2673d0e3c37f38"
+  integrity sha512-7p2wweoJYhim8YUy3ih1SrPGqRsa6+aEFbYgo9v4zt7b3tOva8SvkbC2alayK74fclzQ7umqa6xAwvWhy8ORvg==
   dependencies:
-    "@angular-devkit/core" "9.1.1"
-    "@angular-devkit/schematics" "9.1.1"
+    "@angular-devkit/core" "11.0.5"
+    "@angular-devkit/schematics" "11.0.5"
+    jsonc-parser "2.3.1"
 
-"@schematics/schematics@0.901.1":
-  version "0.901.1"
-  resolved "https://registry.yarnpkg.com/@schematics/schematics/-/schematics-0.901.1.tgz#265db2a82f68371d629ee14e7e3e4b349a362899"
-  integrity sha512-wWPrTP9LXKTYIR0gpGLL4EnDub7NWrGcdmJhEHQxCBtBVYQp6OkRK8JgWran/AiCLMDqdI3NRqOOznbrKnelqQ==
+"@schematics/schematics@0.1100.5":
+  version "0.1100.5"
+  resolved "https://registry.yarnpkg.com/@schematics/schematics/-/schematics-0.1100.5.tgz#2b9ee52891fe435fe2d7565fb16e12f96345798a"
+  integrity sha512-hqRX9ZYLwR482lqfTKA3lTm0LkjryGvZfnxP+TiakcT4d5zl6IczWRwgGJDCADoNvVsIJ3sZtWB4af/JxLYA5A==
   dependencies:
-    "@angular-devkit/core" "9.1.1"
-    "@angular-devkit/schematics" "9.1.1"
+    "@angular-devkit/core" "11.0.5"
+    "@angular-devkit/schematics" "11.0.5"
 
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
-"@types/jasmine@^3.3.9":
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-3.4.4.tgz#be3fbd73e72725edb44e6f7f509cd52912d1550c"
-  integrity sha512-+/sHcTPyDS1JQacDRRRWb+vNrjBwnD+cKvTaWlxlJ/uOOFvzCkjOwNaqVjYMLfsjzNi0WtDH9RyReDXPG1Cdug==
+"@types/jasmine@~3.5.0":
+  version "3.5.14"
+  resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-3.5.14.tgz#f41a14e8ffa939062a71cf9722e5ee7d4e1f94af"
+  integrity sha512-Fkgk536sHPqcOtd+Ow+WiUNuk0TSo/BntKkF8wSvcd6M2FvPjeXcUE6Oz/bwDZiUZEaXLslAgw00Q94Pnx6T4w==
 
-"@types/node@^8.0.31":
-  version "8.10.55"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.55.tgz#3951a64ebce1927b050fd1e420dc6f332be8a1e0"
-  integrity sha512-iZeh1EgupfmAAOASk580R1SL5lWF3CsBVgVH0395qyNF8fhO16xy1UwAav2PdGxIIsYRn7RzJgMGjdsvam6YYg==
+"@types/node@^12.11.1":
+  version "12.19.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.19.11.tgz#9220ab4b20d91169eb78f456dbfcbabee89dfb50"
+  integrity sha512-bwVfNTFZOrGXyiQ6t4B9sZerMSShWNsGRw8tC5DY1qImUNczS9SjT4G6PnzjCnxsu5Ubj6xjL2lgwddkxtQl5w==
 
-ajv@6.12.0:
-  version "6.12.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.0.tgz#06d60b96d87b8454a5adaba86e7854da629db4b7"
-  integrity sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==
+ajv@6.12.6:
+  version "6.12.6"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
+  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
+
+ansi-colors@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
+  integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
 
 ansi-escapes@^4.2.1:
   version "4.2.1"
@@ -92,13 +98,6 @@ ansi-regex@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
-
-ansi-styles@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
-  integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
-  dependencies:
-    color-convert "^1.9.0"
 
 ansi-styles@^4.1.0:
   version "4.2.1"
@@ -121,19 +120,10 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-chalk@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
-  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
-  dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
-
-chalk@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
-  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+chalk@^4.0.0, chalk@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
+  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -150,27 +140,20 @@ cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
-cli-spinners@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.3.0.tgz#0632239a4b5aa4c958610142c34bb7a651fc8df5"
-  integrity sha512-Xs2Hf2nzrvJMFKimOR7YR0QwZ8fc0u98kdtwN1eNAZzNQgH3vK2pXzff6GJtKh7S5hoJ87ECiAiZFS2fb5Ii2w==
+cli-spinners@^2.4.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.5.0.tgz#12763e47251bf951cb75c201dfa58ff1bcb2d047"
+  integrity sha512-PC+AmIuK04E6aeSs/pUccSujsTzBhu4HzC2dL+CfJB/Jcc2qTRbEwZQDfIUpt2Xl8BodYBEq8w4fc0kU2I9DjQ==
 
-cli-width@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
-  integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
+cli-width@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
+  integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
 
 clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
-
-color-convert@^1.9.0:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
-  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
-  dependencies:
-    color-name "1.1.3"
 
 color-convert@^2.0.1:
   version "2.0.1"
@@ -178,11 +161,6 @@ color-convert@^2.0.1:
   integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
   dependencies:
     color-name "~1.1.4"
-
-color-name@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
-  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
 color-name@~1.1.4:
   version "1.1.4"
@@ -247,10 +225,10 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-glob@^7.1.4:
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
-  integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
+glob@^7.1.6:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -258,11 +236,6 @@ glob@^7.1.4:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
-
-has-flag@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
-  integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
 has-flag@^4.0.0:
   version "4.0.0"
@@ -289,21 +262,21 @@ inherits@2:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-inquirer@7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.1.0.tgz#1298a01859883e17c7264b82870ae1034f92dd29"
-  integrity sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==
+inquirer@7.3.3:
+  version "7.3.3"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.3.3.tgz#04d176b2af04afc157a83fd7c100e98ee0aad003"
+  integrity sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==
   dependencies:
     ansi-escapes "^4.2.1"
-    chalk "^3.0.0"
+    chalk "^4.1.0"
     cli-cursor "^3.1.0"
-    cli-width "^2.0.0"
+    cli-width "^3.0.0"
     external-editor "^3.0.3"
     figures "^3.0.0"
-    lodash "^4.17.15"
+    lodash "^4.17.19"
     mute-stream "0.0.8"
     run-async "^2.4.0"
-    rxjs "^6.5.3"
+    rxjs "^6.6.0"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
     through "^2.3.6"
@@ -323,35 +296,40 @@ is-promise@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
   integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
 
-jasmine-core@~3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-3.5.0.tgz#132c23e645af96d85c8bca13c8758b18429fc1e4"
-  integrity sha512-nCeAiw37MIMA9w9IXso7bRaLl+c/ef3wnxsoSAlYrzS+Ot0zTG6nU8G/cIfGkqpkjX2wNaIW9RFG0TwIFnG6bA==
+jasmine-core@~3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-3.6.0.tgz#491f3bb23941799c353ceb7a45b38a950ebc5a20"
+  integrity sha512-8uQYa7zJN8hq9z+g8z1bqCfdC8eoDAeVnM5sfqs7KHv9/ifoJ500m018fpFc7RDaO6SWCLCXwo/wPSNcdYTgcw==
 
-jasmine@^3.3.1:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/jasmine/-/jasmine-3.5.0.tgz#7101eabfd043a1fc82ac24e0ab6ec56081357f9e"
-  integrity sha512-DYypSryORqzsGoMazemIHUfMkXM7I7easFaxAvNM3Mr6Xz3Fy36TupTrAOxZWN8MVKEU5xECv22J4tUQf3uBzQ==
+jasmine@^3.5.0:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/jasmine/-/jasmine-3.6.3.tgz#520cd71f76bd8251e9f566b622e13602e9ddcf26"
+  integrity sha512-Th91zHsbsALWjDUIiU5d/W5zaYQsZFMPTdeNmi8GivZPmAaUAK8MblSG3yQI4VMGC/abF2us7ex60NH1AAIMTA==
   dependencies:
-    glob "^7.1.4"
-    jasmine-core "~3.5.0"
+    glob "^7.1.6"
+    jasmine-core "~3.6.0"
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
-lodash@^4.17.15:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+jsonc-parser@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-2.3.1.tgz#59549150b133f2efacca48fe9ce1ec0659af2342"
+  integrity sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==
 
-log-symbols@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-3.0.0.tgz#f3a08516a5dea893336a7dee14d18a1cfdab77c4"
-  integrity sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==
+lodash@^4.17.19:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
+log-symbols@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.0.0.tgz#69b3cc46d20f448eccdb75ea1fa733d9e821c920"
+  integrity sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==
   dependencies:
-    chalk "^2.4.2"
+    chalk "^4.0.0"
 
 magic-string@0.25.7:
   version "0.25.7"
@@ -396,16 +374,16 @@ onetime@^5.1.0:
   dependencies:
     mimic-fn "^2.1.0"
 
-ora@4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/ora/-/ora-4.0.3.tgz#752a1b7b4be4825546a7a3d59256fa523b6b6d05"
-  integrity sha512-fnDebVFyz309A73cqCipVL1fBZewq4vwgSHfxh43vVy31mbyoQ8sCH3Oeaog/owYOs/lLlGVPCISQonTneg6Pg==
+ora@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-5.1.0.tgz#b188cf8cd2d4d9b13fd25383bc3e5cba352c94f8"
+  integrity sha512-9tXIMPvjZ7hPTbk8DFq1f7Kow/HU/pQYB60JbNq+QnGwcyhWVZaQ4hM9zQDEsPxw/muLpgiHSaumUZxCAmod/w==
   dependencies:
-    chalk "^3.0.0"
+    chalk "^4.1.0"
     cli-cursor "^3.1.0"
-    cli-spinners "^2.2.0"
+    cli-spinners "^2.4.0"
     is-interactive "^1.0.0"
-    log-symbols "^3.0.0"
+    log-symbols "^4.0.0"
     mute-stream "0.0.8"
     strip-ansi "^6.0.0"
     wcwidth "^1.0.1"
@@ -445,17 +423,10 @@ run-async@^2.4.0:
   dependencies:
     is-promise "^2.1.0"
 
-rxjs@6.5.4:
-  version "6.5.4"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.4.tgz#e0777fe0d184cec7872df147f303572d414e211c"
-  integrity sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==
-  dependencies:
-    tslib "^1.9.0"
-
-rxjs@^6.5.3:
-  version "6.5.5"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.5.tgz#c5c884e3094c8cfee31bf27eb87e54ccfc87f9ec"
-  integrity sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==
+rxjs@6.6.3, rxjs@^6.6.0:
+  version "6.6.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
+  integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
   dependencies:
     tslib "^1.9.0"
 
@@ -502,13 +473,6 @@ strip-ansi@^6.0.0:
   dependencies:
     ansi-regex "^5.0.0"
 
-supports-color@^5.3.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
-  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
-  dependencies:
-    has-flag "^3.0.0"
-
 supports-color@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
@@ -516,10 +480,10 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-symbol-observable@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
-  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
+symbol-observable@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-2.0.3.tgz#5b521d3d07a43c351055fa43b8355b62d33fd16a"
+  integrity sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA==
 
 through@^2.3.6:
   version "2.3.8"
@@ -543,10 +507,10 @@ type-fest@^0.5.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.5.2.tgz#d6ef42a0356c6cd45f49485c3b6281fc148e48a2"
   integrity sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==
 
-typescript@~3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
-  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
+typescript@~4.0.2:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
+  integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
 
 uri-js@^4.2.2:
   version "4.2.2"


### PR DESCRIPTION
`@angular-devkit/core` の major version が上がったために `experimental.workspace` が存在しなくなったため `WorkspaceSchema` は https://github.com/angular/angular-cli/blob/v11.0.5/packages/schematics/angular/utility/workspace-models.ts から読み込むように変更。